### PR TITLE
Potential fix for code scanning alert no. 12: Clear text storage of sensitive information

### DIFF
--- a/src/slskd/Program.cs
+++ b/src/slskd/Program.cs
@@ -314,7 +314,8 @@ namespace slskd
                 var (filename, password) = GenerateX509Certificate(password: Cryptography.Random.GetBytes(16).ToBase62(), filename: $"{AppName}.pfx");
 
                 Log.Information($"Certificate exported to {filename}");
-                Log.Information($"Password: {password}");
+                // Do not log the password to logs; output to console only for user visibility.
+                Console.WriteLine($"Password: {password}");
                 return;
             }
 


### PR DESCRIPTION
Potential fix for [https://github.com/sredevopsorg/slskd/security/code-scanning/12](https://github.com/sredevopsorg/slskd/security/code-scanning/12)

The best way to fix this problem is to avoid logging the password in cleartext using the general logging infrastructure. Instead, the password should be communicated to the user in a secure manner. If the application is running in an interactive console, the password can be written directly to the console (e.g., using `Console.WriteLine`), which is less likely to be persisted or exposed than application logs. If the application is not running interactively, consider writing the password to a secure location or prompting the user to provide their own password.

**Specific changes:**
- In `src/slskd/Program.cs`, replace the line that logs the password (`Log.Information($"Password: {password}");`) with a direct console output (`Console.WriteLine($"Password: {password}");`).
- Ensure that the `System` namespace is imported (it already is).
- Optionally, add a comment explaining why the password is not logged.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
